### PR TITLE
use comma as thousands separator on number of token

### DIFF
--- a/src/components/ReflectionTracker.js
+++ b/src/components/ReflectionTracker.js
@@ -192,6 +192,10 @@ const ReflectionTracker = () => {
     return percentage
   }, [values])
 
+  function numberCommaSeparator(x) {
+    return x.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
+  }
+
   const Input = ({ title, value, onChange }) => {
     return (
       <div className="relative m-5">
@@ -231,22 +235,22 @@ const ReflectionTracker = () => {
           <div className="grid gap-x-24 grid-cols-1 mt-5 sm:grid-cols-1 md:grid-cols-2">
             <Input
               title="Your balance"
-              value={values.balance}
+              value={numberCommaSeparator(values.balance)}
               onChange={e => setValues({ ...values, balance: e.target.value })}
             />
             <Input
               title="Total reflections"
-              value={values.reflections}
+              value={numberCommaSeparator(values.reflections)}
               onChange={e => setValues({ ...values, reflections: e.target.value })}
             />
             <Input
               title="# of GLORYD purchased"
-              value={values.purchased}
+              value={numberCommaSeparator(values.purchased)}
               onChange={e => setValues({ ...values, purchased: e.target.value })}
             />
             <Input
               title="# of GLORYD sold ( 0 = Diamond hands )"
-              value={values.sold}
+              value={numberCommaSeparator(values.sold)}
               onChange={e => setValues({ ...values, sold: e.target.value })}
             />
           </div>

--- a/src/components/ReflectionTracker.js
+++ b/src/components/ReflectionTracker.js
@@ -8,10 +8,10 @@ import Container from './Container'
 
 const ReflectionTracker = () => {
   const initValues = {
-    balance: { value: 0, usd: '' },
-    reflections: { value: 0, usd: '' },
-    purchased: { value: 0, usd: '' },
-    sold: { value: 0, usd: '' },
+    balance: { value: 0, usd: 0 },
+    reflections: { value: 0, usd: 0 },
+    purchased: { value: 0, usd: 0 },
+    sold: { value: 0, usd: 0 },
   }
   const [token, setToken] = useState('')
   const [values, setValues] = useState(initValues)
@@ -161,11 +161,10 @@ const ReflectionTracker = () => {
     return (
       <div className="relative m-1 sm:m-5">
         <div className="flex">
-          <p className="mb-5 text-base">{title}</p>
-          {token && !loading && usd !== 0 && (
+          <p className="mb-2 text-base">{title}</p>
+          {token && !loading && (
             <>
-              <p className="w-[180px] ml-1 truncate">({usd}</p>
-              <p>USD)</p>
+              <p className="w-[180px] ml-1 truncate">({numberCommaSeparator(parseFloat(usd).toFixed(2))} USD)</p>
             </>
           )}
         </div>
@@ -174,7 +173,7 @@ const ReflectionTracker = () => {
             placeholder="0.00000"
             type="text"
             className="h-[40px] bg-[#041622] disabled px-4 w-full text-2xl rounded-lg outline-none opacity-100 truncate"
-            value={value}
+            value={numberCommaSeparator(value)}
             onChange={onChange}
           />
         </div>
@@ -202,25 +201,25 @@ const ReflectionTracker = () => {
           <div className="grid gap-x-24 grid-cols-1 mt-5 sm:grid-cols-1 md:grid-cols-2">
             <Input
               title="Your balance"
-              value={numberCommaSeparator(values.balance.value)}
+              value={values.balance.value}
               usd={values.balance.usd}
               onChange={e => setValues({ ...values, balance: { value: e.target.value } })}
             />
             <Input
               title="Total reflections"
-              value={numberCommaSeparator(values.reflections.value)}
+              value={values.reflections.value}
               usd={values.reflections.usd}
               onChange={e => setValues({ ...values, reflections: { value: e.target.value } })}
             />
             <Input
               title="# of GLORYD purchased"
-              value={numberCommaSeparator(values.purchased.value)}
+              value={values.purchased.value}
               usd={values.purchased.usd}
               onChange={e => setValues({ ...values, purchased: { value: e.target.value } })}
             />
             <Input
               title="# of GLORYD sold"
-              value={numberCommaSeparator(values.sold.value)}
+              value={values.sold.value}
               usd={values.sold.usd}
               onChange={e => setValues({ ...values, sold: { value: e.target.value } })}
             />

--- a/src/components/ReflectionTracker.js
+++ b/src/components/ReflectionTracker.js
@@ -153,6 +153,10 @@ const ReflectionTracker = () => {
     return percentage
   }, [values])
 
+  function numberCommaSeparator(value) {
+    return value.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
+  }
+
   const Input = ({ title, value, onChange, usd }) => {
     return (
       <div className="relative m-1 sm:m-5">
@@ -198,25 +202,25 @@ const ReflectionTracker = () => {
           <div className="grid gap-x-24 grid-cols-1 mt-5 sm:grid-cols-1 md:grid-cols-2">
             <Input
               title="Your balance"
-              value={values.balance.value}
+              value={numberCommaSeparator(values.balance.value)}
               usd={values.balance.usd}
               onChange={e => setValues({ ...values, balance: { value: e.target.value } })}
             />
             <Input
               title="Total reflections"
-              value={values.reflections.value}
+              value={numberCommaSeparator(values.reflections.value)}
               usd={values.reflections.usd}
               onChange={e => setValues({ ...values, reflections: { value: e.target.value } })}
             />
             <Input
               title="# of GLORYD purchased"
-              value={values.purchased.value}
+              value={numberCommaSeparator(values.purchased.value)}
               usd={values.purchased.usd}
               onChange={e => setValues({ ...values, purchased: { value: e.target.value } })}
             />
             <Input
               title="# of GLORYD sold"
-              value={values.sold.value}
+              value={numberCommaSeparator(values.sold.value)}
               usd={values.sold.usd}
               onChange={e => setValues({ ...values, sold: { value: e.target.value } })}
             />


### PR DESCRIPTION
- Merge & resolve conflict with upstream repo 
- Implement comma as thousands separator on number of token, so it will be easier to read.
- USD value limit to 2
- comma separator for USD value

Example:
> 56130212063.720795 will be displayed as: 989,579,850.1971893